### PR TITLE
signal_connecting: fix numeric enter key for dialogs

### DIFF
--- a/addons/pronto/signal_connecting/function_name.gd
+++ b/addons/pronto/signal_connecting/function_name.gd
@@ -15,7 +15,7 @@ func _gui_input(event):
 		match event.keycode:
 			KEY_DOWN: move_focus(1)
 			KEY_UP: move_focus(-1)
-			KEY_ENTER:
+			KEY_ENTER, KEY_KP_ENTER:
 				selected(get_focused_index())
 
 func get_focused_index():

--- a/addons/pronto/signal_connecting/node_to_node_configurator.gd
+++ b/addons/pronto/signal_connecting/node_to_node_configurator.gd
@@ -51,7 +51,7 @@ var selected_signal: Dictionary:
 func _input(event):
 	if event is InputEventKey and event.keycode == KEY_ESCAPE and event.pressed:
 		_on_cancel_pressed()
-	if event is InputEventKey and event.keycode == KEY_ENTER and event.pressed and event.ctrl_pressed:
+	if event is InputEventKey and (event.keycode == KEY_ENTER or event.keycode == KEY_KP_ENTER) and event.pressed and event.ctrl_pressed:
 		_on_done_pressed()
 
 var receiver: Object:


### PR DESCRIPTION
For confirming a node-to-node dialog or selecting a function name, the right Enter key should be usable interchangeably with the left Enter key.