### PR TITLE
Allow connections from non-Behavior nodes

### DIFF
--- a/addons/pronto/pronto.gd
+++ b/addons/pronto/pronto.gd
@@ -109,12 +109,7 @@ func _is_editing_behavior():
 	if not is_instance_valid(edited_object):
 		# edited_object might be freed after inspecting an object from a prior debugging session
 		return false
-	if not edited_object.has_method('_forward_canvas_draw_over_viewport'):
-		# edited_object is EditorDebuggerRemoteObject, which we can only use to retrieve state
-		# but not to interact with
-		# https://github.com/hpi-swa-lab/godot-pronto/pull/22
-		return false
-	return edited_object is Behavior
+	return edited_object
 
 func show_signals(node: Node):
 	if popup:

--- a/addons/pronto/pronto.gd
+++ b/addons/pronto/pronto.gd
@@ -73,7 +73,7 @@ func _handles(object):
 	return !pronto_should_ignore(object)
 
 func _edit(object):
-	if _is_editing_behavior():
+	if _is_editing_behavior() and edited_object.has_method("deselected"):
 		edited_object.deselected()
 	
 	# get_editor_interface().edit_script(load("res://examples/platformer.tscn::GDScript_tb7ap"))
@@ -96,13 +96,15 @@ func _make_visible(visible):
 func _forward_canvas_gui_input(event):
 	if not _is_editing_behavior():
 		return false
+	if not edited_object.has_method("_forward_canvas_gui_input"):
+		return false
 	var ret = edited_object._forward_canvas_gui_input(event, get_undo_redo())
 	if ret:
 		update_overlays()
 	return ret
 
 func _forward_canvas_draw_over_viewport(viewport_control):#
-	if _is_editing_behavior():
+	if _is_editing_behavior() and edited_object.has_method("_forward_canvas_draw_over_viewport"):
 		return edited_object._forward_canvas_draw_over_viewport(viewport_control)
 
 func _is_editing_behavior():

--- a/addons/pronto/signal_connecting/connect.gd
+++ b/addons/pronto/signal_connecting/connect.gd
@@ -63,7 +63,7 @@ func _process(delta):
 		var name = %connections.get_item_text(idx)
 		var conn = Utils.find(Connection.get_connections(node),
 			func (c: Connection): return c.print(false, false, true) == name)
-		if conn:
+		if conn and node.has_method("highlight_activated"):
 			node.highlight_activated(conn)
 
 func _on_add_mouse_entered():


### PR DESCRIPTION
This removes a check for a specific method on selected objects. It undoes parts of #22 and will need further review.
Closes #57 

**Progress:**
- [x] Connecting signals from non-Behavior nodes
- [x] Allowing edits of these connections
- [x] Check relevant methods where Behaviors are expected (Mostly related to Godot's Editor plugins and handling of input)

**TODO:**
- [ ] Render connections from non-Behavior nodes
- [ ] Refactor [method checks](#Duck-typing)

**Rendering of connection lines:**
Behavior nodes override their `_draw()` method to draw their own connections.
Non-Behavior nodes would need to have their connections drawn by another node.
As they are most probably going to be `CanvasItem`s, we could use the `draw()` signal (emitted after the notification, before `_draw()` is called) in combination with something like a `ConnectionDrawer` to render connections.
This will need further research.

Another idea would be to bypass `Behavior` completely for drawing connections and instead render them all every time the canvas needs to be redrawn. In my testing, rendering a `Behavior` happens only when zooming the editor and moving a `Behavior` which already has at least one connection.

**Duck-typing vs explicit type checking:**
This PR also makes changes to code relying on a passed node to have certain methods only found on `Behavior`.
This code now first checks whether the requested method actually exists.
That means, that - theoretically - any node implementing those methods would pass the test, but might not behave as expected. Maybe we should do an explicit check for `node is Behavior` instead? 
I cannot think of any potential gains by allowing [duck-typing](https://en.wikipedia.org/wiki/Duck_typing) here, since we actually expect some very specific code to be executed (Methods like `_forward_canvas_draw_over_viewport`).
Furthermore, some methods have generic names like `deselected()` which could well be part of an unrelated Class's interface.
