### PR TITLE
Add flash animation to placeholder

### DIFF
--- a/addons/pronto/behaviors/Placeholder.gd
+++ b/addons/pronto/behaviors/Placeholder.gd
@@ -132,6 +132,22 @@ func set_outline_visible(visible):
 	else:
 		show_outline()
 
+
+## Tween used for flashing
+var _flash_tween : Tween
+
+## Flashes this Placeholder a certain color for a duration.
+## It will take on the desired color immediately and return to its original
+## color over the given duration.
+func flash(color: Color, duration: float = 0.2):
+	if _flash_tween:
+		_flash_tween.kill()
+	_flash_tween = create_tween()
+	
+	_flash_tween.tween_property(self, "modulate", self.color, duration)
+	_flash_tween.set_ease(Tween.EASE_OUT)
+	modulate = color
+
 func should_keep_in_origin():
 	return keep_in_origin and get_parent() is CollisionObject2D
 

--- a/addons/pronto/behaviors/Placeholder.gd
+++ b/addons/pronto/behaviors/Placeholder.gd
@@ -136,17 +136,23 @@ func set_outline_visible(visible):
 ## Tween used for flashing
 var _flash_tween : Tween
 
+## Color to restore when restarting flash
+var _restore_color : Color
+
 ## Flashes this Placeholder a certain color for a duration.
 ## It will take on the desired color immediately and return to its original
 ## color over the given duration.
 func flash(color: Color, duration: float = 0.2):
 	if _flash_tween:
+		if _flash_tween.is_running():
+			self.color = _restore_color
 		_flash_tween.kill()
-	_flash_tween = create_tween()
 	
-	_flash_tween.tween_property(self, "modulate", self.color, duration)
+	_restore_color = self.color
+	_flash_tween = create_tween()
+	_flash_tween.tween_property(self, "color", self.color, duration)
 	_flash_tween.set_ease(Tween.EASE_OUT)
-	modulate = color
+	self.color = color
 
 func should_keep_in_origin():
 	return keep_in_origin and get_parent() is CollisionObject2D


### PR DESCRIPTION
Adds the `flash(color, duration)` method to `Placeholder` to allow a quick visual update.
It uses a tween to animate the `color` property, so any writes to that will be overwritten while the flash is happening.
Calling `flash()` again while the previous has not finished will restart it.

Closes #56 