### PR TITLE
Fixed #160 through explicit addition of KEY_TAB

### DIFF
--- a/addons/pronto/signal_connecting/function_name.gd
+++ b/addons/pronto/signal_connecting/function_name.gd
@@ -6,16 +6,19 @@ var anchor
 
 signal method_selected(name: String)
 
+var _gui_input_keycode
+
 func add_class_item(name):
 	var behaviors = G.at("_pronto_behaviors")
 	%list.add_item(name, Utils.icon_from_theme(behaviors[name], anchor) if name in behaviors else Utils.icon_for_class(name, anchor), false)
 
 func _gui_input(event):
 	if event is InputEventKey and event.pressed:
+		_gui_input_keycode = event.keycode
 		match event.keycode:
 			KEY_DOWN: move_focus(1)
 			KEY_UP: move_focus(-1)
-			KEY_ENTER, KEY_KP_ENTER:
+			KEY_ENTER, KEY_KP_ENTER, KEY_TAB:
 				accept_selected()
 
 func accept_selected():
@@ -31,7 +34,8 @@ func selected(index: int):
 	%list.visible = false
 	text = %list.get_item_text(index)
 	method_selected.emit(text)
-	find_next_valid_focus().grab_focus()
+	if _gui_input_keycode != KEY_TAB:
+		find_next_valid_focus().grab_focus()
 
 func move_focus(dir: int):
 	var current = get_focused_index() + dir


### PR DESCRIPTION
Added KEY_TAB to register for accepting the selected method from the autocompletion drow-down window in the node_to_node_configurator dialog.
It is necessary to either undo or prevent the additional focus switch that tab triggered.
As we can't use the `find_prev_valid_focus` method to do this in the `_gui_input` method (because we are at the first index) we instead check the key type again in the `selected` method and prevent additional focus movement if the key type was tab.