### PR TITLE
Bugfix/#162/prevent protoui value duplication

### DIFF
--- a/addons/pronto/behaviors/PrototypingUIBehavior.gd
+++ b/addons/pronto/behaviors/PrototypingUIBehavior.gd
@@ -136,7 +136,6 @@ func _input(event):
 		is_resizing = false
 
 func _build_panel():
-	print("Build panel called")
 	if not get_tree(): # This happens on godot startup
 		return
 	_clear_panel()
@@ -164,7 +163,6 @@ func _build_panel():
 	
 	scrollContainer.add_child(vbox)
 	scrollContainer.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	
 	
 	var outerVbox = VBoxContainer.new()
 	outerVbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -399,11 +397,14 @@ func _proccessed_duplicate_node(node):
 	var name = node.name
 	for entry in vbox.get_children():
 		var value_label
+		# layout is different based on value type
+		# vbox = float ValueBehavior
 		if is_instance_of(entry, VBoxContainer):
 			value_label = entry.get_child(0).get_child(1).get_child(0)
 			if name == value_label.text.substr(0,value_label.text.length()-1):
 				_update_duplicate_counter(entry)
 				return true
+		# hbox = bool/enum ValueBehavior
 		if is_instance_of(entry, HBoxContainer):
 			value_label = entry.get_child(1)
 			if name == value_label.text.substr(0,value_label.text.length()-1):
@@ -413,36 +414,42 @@ func _proccessed_duplicate_node(node):
 			value_label = entry
 			if name == value_label.text:
 				return true
-	return false			
+	return false
 
 func _update_duplicate_counter(entry):
 	if is_instance_of(entry, VBoxContainer):
+		# check if it already has a duplicate-counter label
 		if entry.get_child(0).get_child(1).get_child_count() == 1:
 			var counter_label = _prepare_counter_label()
 			entry.get_child(0).get_child(1).add_child(counter_label)
 		else:	
 			var counter_label = entry.get_child(0).get_child(1).get_child(1)
-			counter_label.text = str(int(counter_label.text.substr(0,counter_label.text.length()-1)) + 1) + "x"
+			counter_label.text = "+" + str(int(counter_label.text.substr(1,counter_label.text.length())) + 1)
 	if is_instance_of(entry, HBoxContainer):
+		# check if it already has a duplicate-counter label
 		if not is_instance_of(entry.get_child(2), Label):
 			var counter_label = _prepare_counter_label()
 			entry.add_child(counter_label)
 			entry.move_child(counter_label, 2)
 		else:
 			var counter_label = entry.get_child(2)
-			counter_label.text = str(int(counter_label.text.substr(0,counter_label.text.length()-1)) + 1) + "x"
+			counter_label.text = "+" + str(int(counter_label.text.substr(1,counter_label.text.length())) + 1)
 	if is_instance_of(entry, CodeEdit):
-		# todo: think of a smart way to do this
+		# todo: figure out if we want to do anything for multiple CodeEdits
 		pass
 			
 func _prepare_counter_label():
 	var counter_label = Label.new()
 	counter_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
+	counter_label.size_flags_vertical = Control.SIZE_FILL
 	counter_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	counter_label.text = "+1"
+	# tooltip doesn't get displayed, feel free to fix
+	counter_label.tooltip_text = "This value exists multiple times in the scene"
+	
 	var label_settings = LabelSettings.new()
 	label_settings.font_size = 8
 	counter_label.label_settings = label_settings
-	counter_label.text = "2x"
 	return counter_label
 			
 func _build_edit_menu(edit_hbox: HBoxContainer, value: ValueBehavior, \
@@ -579,7 +586,6 @@ func create_minimizing_button():
 		handle_size_button_click(button, true)
 	return button
 	
-
 func create_header():
 	var hbox = HBoxContainer.new()
 	hbox.add_child(create_minimizing_button())


### PR DESCRIPTION
With the changes from #155b5f4 and #32140b4 the prototyping ui will not display duplicate Value- or CodeBehaviors.
Instead, it will display a little +1,+2,+3... counter next to the variable name for ValueBehaviors. 
![image](https://github.com/hpi-swa-lab/godot-pronto/assets/29424520/526be2e4-30a9-4872-b0aa-ab5475b504db)
For CodeBehaviors this counter was deemed unnecessary but can easily be added to the code at a later point in time.
The code introduced for this issue can surely still be improved as for now the handling is done based on child types and counts within the prototyping ui.
Let me know if any changes are required before merging.

